### PR TITLE
[+] Add dynamic dependency loader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,16 +32,23 @@ repositories {
     maven {
         url = "https://ci.ender.zone/plugin/repository/everything/"
     }
+
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
+
+    implementation 'com.saicone.ezlib:ezlib:1.1'
+
     compileOnly "io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT"
     compileOnly "world.bentobox:bentobox:1.21.0-SNAPSHOT"
     compileOnly "com.bgsoftware:SuperiorSkyblockAPI:2023.3"
     compileOnly "com.massivecraft:Factions:1.6.9.5-U0.6.21"
 
-    implementation("org.mongodb:mongodb-driver-sync:4.9.1")
-    implementation("com.zaxxer:HikariCP:5.0.1")
+    compileOnly("org.mongodb:mongodb-driver-sync:4.9.1")
+    compileOnly("com.zaxxer:HikariCP:5.1.0")
 }
 
 def targetJavaVersion = 17
@@ -73,5 +80,9 @@ processResources {
 
 shadowJar {
     destinationDirectory.set(file("out"))
+    relocate 'com.saicone.ezlib', project.group + '.hdrawer.lib.ezlib'
+    relocate 'com.mongodb', project.group + '.hdrawer.lib.mongodb'
+    relocate 'com.zaxxer.hikari', project.group + '.hdrawer.lib.hikari'
     archiveName = "${project.name}-${project.version}.jar"
+    minimize()
 }

--- a/src/main/java/fr/hokib/hdrawer/HDrawer.java
+++ b/src/main/java/fr/hokib/hdrawer/HDrawer.java
@@ -7,6 +7,7 @@ import fr.hokib.hdrawer.database.Database;
 import fr.hokib.hdrawer.database.logger.DatabaseLogger;
 import fr.hokib.hdrawer.database.task.SaveTask;
 import fr.hokib.hdrawer.database.type.DatabaseType;
+import fr.hokib.hdrawer.lib.HDrawerDeps;
 import fr.hokib.hdrawer.listener.DrawerListener;
 import fr.hokib.hdrawer.manager.DrawerManager;
 import fr.hokib.hdrawer.manager.hopper.HopperManager;
@@ -29,6 +30,11 @@ public final class HDrawer extends JavaPlugin {
 
     public static HDrawer get() {
         return instance;
+    }
+
+    @Override
+    public void onLoad() {
+        new HDrawerDeps(this).load();
     }
 
     @Override

--- a/src/main/java/fr/hokib/hdrawer/lib/Dependency.java
+++ b/src/main/java/fr/hokib/hdrawer/lib/Dependency.java
@@ -1,0 +1,85 @@
+package fr.hokib.hdrawer.lib;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Dependency {
+    private static final String MAVEN_REPOSITORY = "https://repo.maven.apache.org/maven2/";
+    // Adventure
+    @Getter
+    private final String test;
+    @Getter
+    private final String path;
+    @Getter
+    private final String repository;
+    @Getter
+    private final boolean inner;
+    @Getter
+    private final Relocation relocation;
+
+    private Map<String, String> relocationMap;
+
+    public Dependency(String test, String path, Relocation... relocations) {
+        this(test, path, MAVEN_REPOSITORY, relocations);
+    }
+
+    public Dependency(String test, String path, String repository, Relocation... relocations) {
+        this(test, path, repository, false, relocations);
+    }
+
+    public Dependency(String test, String path, boolean inner, Relocation... relocations) {
+        this(test, path, MAVEN_REPOSITORY, inner, relocations);
+    }
+
+    public Dependency(String test, String path, String repository, boolean inner, Relocation... relocations) {
+        this.test = LibraryLoader.alias(test);
+        this.path = LibraryLoader.alias(path);
+        this.repository = repository;
+        this.inner = inner;
+        if (relocations.length == 1) {
+            this.relocation = relocations[0];
+            return;
+        } else if (relocations.length == 0) {
+            this.relocation = Relocation.of();
+            return;
+        }
+
+        int size = 0;
+        for (Relocation relocation : relocations) {
+            size = size + relocation.size();
+        }
+        if (size < 1) {
+            this.relocation = Relocation.of();
+            return;
+        }
+
+        String[] from = new String[size];
+        String[] to = new String[size];
+        for (int i = 0; i < size; i++) {
+            for (Relocation relocation : relocations) {
+                for (int i1 = 0; i1 < relocation.size(); i1++) {
+                    from[i] = relocation.from[i1];
+                    to[i] = relocation.to[i1];
+                    i++;
+                }
+            }
+        }
+        this.relocation = new Relocation(from, to);
+    }
+
+    public Map<String, String> getRelocationMap() {
+        if (relocationMap == null) {
+            Map<String, String> map = new HashMap<>();
+            for (int i = 0; i < relocation.size(); i++) {
+                String key = LibraryLoader.alias(relocation.from[i]);
+                String value = LibraryLoader.alias(relocation.to[i]);
+                map.put(key, value);
+            }
+            relocationMap = map;
+        }
+        return relocationMap;
+    }
+
+}

--- a/src/main/java/fr/hokib/hdrawer/lib/HDrawerDeps.java
+++ b/src/main/java/fr/hokib/hdrawer/lib/HDrawerDeps.java
@@ -1,0 +1,84 @@
+package fr.hokib.hdrawer.lib;
+
+import lombok.Getter;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Arrays;
+
+public class HDrawerDeps extends LibraryLoader {
+    public HDrawerDeps(JavaPlugin plugin) {
+        super(plugin);
+    }
+
+    @Getter
+    private enum Libs {
+        SLF4J_API(
+                "{0}.Logger",
+                "org{}slf4j:slf4j-api:1.7.6",
+                Relocation.of("org{}slf4j", "{package}.slf4j")
+        ),
+        SLF4J_NOP(
+                "{0}.impl.StaticLoggerBinder",
+                "org{}slf4j:slf4j-nop:1.7.6",
+                Relocation.of("org{}slf4j", "{package}.lib.slf4j"),
+                SLF4J_API.deps.getRelocation()
+        ),
+        MONGODB_BSON(
+                "{0}.client.BSON",
+                "org{}mongodb:bson:4.9.1",
+                Relocation.of("com{}mongodb", "{package}.mongodb"),
+                SLF4J_API.deps.getRelocation()
+        ),
+        MONGODB_BSON_RECORD_CODEC(
+                "{0}.RecordCodec",
+                "org{}mongodb:bson-record-codec:4.9.1",
+                Relocation.of("com{}mongodb", "{package}.mongodb"),
+                SLF4J_API.deps.getRelocation()
+        ),
+        MONGODB_CORE(
+                "{0}.client.MongoClientSettings",
+                "org{}mongodb:mongodb-driver-core:4.9.1",
+                Relocation.of("com{}mongodb", "{package}.mongodb"),
+                SLF4J_API.deps.getRelocation()
+        ),
+        MONGODB_DRIVER(
+                "{0}.client.MongoClient",
+                "org{}mongodb:mongodb-driver-sync:4.9.1",
+                Relocation.of("com{}mongodb", "{package}.mongodb"),
+                SLF4J_API.deps.getRelocation(),
+                MONGODB_BSON.deps.getRelocation(),
+                MONGODB_CORE.deps.getRelocation()
+        ),
+        HIKARI(
+                "{0}.HikariConfig",
+                "com{}zaxxer:HikariCP:5.1.0",
+                Relocation.of("com{}zaxxer{}hikari", "{package}.hikari"),
+                SLF4J_API.deps.getRelocation()
+        ),
+        ;
+
+        private final Dependency deps;
+
+        private Libs(String test, String path, Relocation... relocations) {
+            this.deps = new Dependency(test, path, relocations);
+        }
+
+        private Libs(String test, String path, String repository, Relocation... relocations) {
+            this.deps = new Dependency(test, path, repository, false, relocations);
+        }
+
+        private Libs(String test, String path, boolean inner, Relocation... relocations) {
+            this.deps = new Dependency(test, path, inner, relocations);
+        }
+
+        private Libs(String test, String path, String repository, boolean inner, Relocation... relocations) {
+            this.deps = new Dependency(test, path,repository, inner, relocations);
+        }
+
+    }
+
+    @Override
+    public Dependency[] getValues() {
+        return Arrays.stream(Libs.values()).map(Libs::getDeps).toArray(Dependency[]::new);
+    }
+}

--- a/src/main/java/fr/hokib/hdrawer/lib/LibraryLoader.java
+++ b/src/main/java/fr/hokib/hdrawer/lib/LibraryLoader.java
@@ -1,0 +1,82 @@
+package fr.hokib.hdrawer.lib;
+
+import com.saicone.ezlib.Ezlib;
+import lombok.Getter;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+
+@Getter
+public abstract class LibraryLoader {
+    private static final String DOT_ALIAS = "{}";
+    private static final String PACKAGE_ALIAS = "{package}";
+
+    private final JavaPlugin plugin;
+    private final Ezlib ezlib;
+
+    protected LibraryLoader(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.ezlib = new Ezlib(new File(plugin.getDataFolder(), "libs")) {
+            // Support for msg library
+            @Override
+            public File download(String dependency, String repository) throws IOException, IllegalArgumentException {
+                String[] split = dependency.split(":", 4);
+                if (split.length < 3) {
+                    throw new IllegalArgumentException("Invalid dependency format");
+                }
+
+                String repo = repository.endsWith("/") ? repository : repository + "/";
+                String version = split[2];
+                String fileVersion;
+                String[] s = version.split("@", 2);
+                if (s.length > 1) {
+                    version = s[0];
+                    fileVersion = s[1];
+                } else {
+                    fileVersion = version;
+                }
+
+                String fileName = split[1] + "-" + fileVersion + (split.length < 4 ? "" : "-" + split[3].replace(":", "-"));
+                String url = repo + split[0].replace(".", "/") + "/" + split[1] + "/" + version + "/" + fileName + ".jar";
+
+                if (!getFolder().exists()) {
+                    getFolder().mkdirs();
+                }
+                File file = new File(getFolder(), fileName + ".jar");
+                return file.exists() ? file : download(url, file);
+            }
+        };
+    }
+
+    public abstract Dependency[] getValues();
+
+    public void load() {
+        for (Dependency dependency : this.getValues()) {
+            try {
+                String name = MessageFormat.format(dependency.getTest(), (Object[]) dependency.getRelocation().to);
+                if (dependency.isInner()) {
+                    Class.forName(name, true, ezlib.getClassLoader());
+                } else {
+                    Class.forName(name);
+                }
+            } catch (ClassNotFoundException e) {
+                plugin.getLogger().info("Loading dependency " + dependency.getPath());
+                ezlib.load(dependency.getPath(), dependency.getRepository(), dependency.getRelocationMap(), !dependency.isInner());
+            }
+        }
+    }
+
+    public ClassLoader getClassLoader() {
+        return getEzlib().getClassLoader();
+    }
+
+    public void close() {
+        ezlib.close();
+    }
+
+    static String alias(String s) {
+        return s.replace(DOT_ALIAS, ".").replace(PACKAGE_ALIAS, LibraryLoader.class.getPackage().getName());
+    }
+}

--- a/src/main/java/fr/hokib/hdrawer/lib/Relocation.java
+++ b/src/main/java/fr/hokib/hdrawer/lib/Relocation.java
@@ -1,0 +1,37 @@
+package fr.hokib.hdrawer.lib;
+
+import static fr.hokib.hdrawer.lib.LibraryLoader.alias;
+
+public class Relocation {
+
+    public final String[] from;
+    public final String[] to;
+
+    public static Relocation of() {
+        return new Relocation(new String[0], new String[0]);
+    }
+
+    public static Relocation of(String from, String to) {
+        return new Relocation(new String[]{alias(from)}, new String[]{alias(to)});
+    }
+
+    public static Relocation of(String from1, String to1, String from2, String to2) {
+        return new Relocation(new String[]{alias(from1), alias(from2)}, new String[]{alias(to1), alias(to2)});
+    }
+
+    public static Relocation of(String from1, String to1, String from2, String to2, String from3, String to3) {
+        return new Relocation(new String[]{alias(from1), alias(from2), alias(from3)}, new String[]{alias(to1), alias(to2), alias(to3)});
+    }
+
+    public static Relocation of(String from1, String to1, String from2, String to2, String from3, String to3, String from4, String to4) {
+        return new Relocation(new String[]{alias(from1), alias(from2), alias(from3), alias(from4)}, new String[]{alias(to1), alias(to2), alias(to3), alias(to4)});
+    }
+
+    public Relocation(String[] from, String[] to) {
+        this.from = from;
+        this.to = to;
+    }
+    public int size() {
+        return from.length;
+    }
+}


### PR DESCRIPTION
Load and Cache libraries dynamicaly to save plugin size and use only the libraries needed.
Libraries are shaded to prevent interfering with other imports.