### PR TITLE
Add support for MC 1.20.5 to 1.21 and prevent deprecated features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-1.19.4 -> 1.20.4 <br/><br/>
-Plugins similar to Storage Drawers mod <br/>
-[SpigotMc](https://www.spigotmc.org/resources/hdrawer.114799/)
+## HDrawer
+
+Supported versions : 1.19.4 -> 1.21
+
+
+Plugins works similary to Storage Drawers mod.
+
+It's available [here](https://www.spigotmc.org/resources/114799/)
 
 Thanks to :
 - [@jj136975](https://github.com/jj136975) (jar size optimization)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "fr.hokib"
-version = "1.2.4"
+version = "1.2.5"
 
 repositories {
     mavenCentral()

--- a/src/main/java/fr/hokib/hdrawer/HDrawer.java
+++ b/src/main/java/fr/hokib/hdrawer/HDrawer.java
@@ -38,7 +38,8 @@ public final class HDrawer extends JavaPlugin {
         new HDrawerDeps(this).load();
     }
 
-    @Override
+    @SuppressWarnings("deprecation")
+	@Override
     public void onEnable() {
         final Version serverVersion = Version.getCurrentVersion();
 

--- a/src/main/java/fr/hokib/hdrawer/database/impl/MySqlDatabase.java
+++ b/src/main/java/fr/hokib/hdrawer/database/impl/MySqlDatabase.java
@@ -130,7 +130,12 @@ public class MySqlDatabase implements Database {
 
         for (int i = 0; i < unsaved.size(); i++) {
             final String location = unsaved.get(i);
-            final DrawerData data = DrawerData.from(manager.getDrawer(location));
+            Drawer drawer = manager.getDrawer(location);
+            if(drawer == null) {
+            	HDrawer.get().getLogger().severe("Failed to save drawer at " + location + " : unable to get it.");
+            	continue;
+            }
+            final DrawerData data = DrawerData.from(drawer);
 
             builder.append("('" + data.id() + "', '" + location + "', '" + data.face() + "', '" + data.content() + "')");
 

--- a/src/main/java/fr/hokib/hdrawer/database/type/DatabaseType.java
+++ b/src/main/java/fr/hokib/hdrawer/database/type/DatabaseType.java
@@ -31,7 +31,7 @@ public enum DatabaseType {
         }
 
         try {
-            return databaseType.databaseClass.newInstance();
+            return databaseType.databaseClass.getConstructor().newInstance();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/fr/hokib/hdrawer/listener/DrawerListener.java
+++ b/src/main/java/fr/hokib/hdrawer/listener/DrawerListener.java
@@ -224,6 +224,7 @@ public class DrawerListener implements Listener {
 
                 event.setCancelled(removed);
             }
+            default -> {}
         }
     }
 }

--- a/src/main/java/fr/hokib/hdrawer/manager/access/AccessAPI.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/access/AccessAPI.java
@@ -28,7 +28,7 @@ public enum AccessAPI {
                     for (final String pluginName : value.getPlugins()) {
                         if (name.equals(pluginName)) {
                             HDrawer.get().getLogger().info("We've found a compatible dependency (" + name + ")");
-                            return value.accessClass.newInstance();
+                            return value.accessClass.getConstructor().newInstance();
                         }
                     }
                 }

--- a/src/main/java/fr/hokib/hdrawer/manager/drawer/Drawer.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/drawer/Drawer.java
@@ -59,7 +59,8 @@ public class Drawer extends DrawerStorage {
         this.borders.clear();
     }
 
-    public void build() {
+    @SuppressWarnings("deprecation")
+	public void build() {
         this.texts.clear();
         this.items.clear();
         this.borders.clear();
@@ -164,7 +165,8 @@ public class Drawer extends DrawerStorage {
         }
     }
 
-    @Override
+    @SuppressWarnings("deprecation")
+	@Override
     public void update(ItemStack itemStack, final int index) {
         if (itemStack.getType().isAir()) itemStack = null;
 

--- a/src/main/java/fr/hokib/hdrawer/util/version/Version.java
+++ b/src/main/java/fr/hokib/hdrawer/util/version/Version.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 public enum Version {
     NONE,
     V1_19_4,
-    V1_20, V1_20_1, V1_20_2, V1_20_3, V1_20_4, V1_20_6;
+    V1_20, V1_20_1, V1_20_2, V1_20_3, V1_20_4, V1_20_6, V1_21;
 
     public static final String REGEX = "MC: (\\d+\\.\\d+(\\.\\d+)?)";
 

--- a/src/main/java/fr/hokib/hdrawer/util/version/Version.java
+++ b/src/main/java/fr/hokib/hdrawer/util/version/Version.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 public enum Version {
     NONE,
     V1_19_4,
-    V1_20, V1_20_1, V1_20_2, V1_20_3, V1_20_4;
+    V1_20, V1_20_1, V1_20_2, V1_20_3, V1_20_4, V1_20_6;
 
     public static final String REGEX = "MC: (\\d+\\.\\d+(\\.\\d+)?)";
 


### PR DESCRIPTION
Changes :
- Prevent issue with deprecated `Class#newInstance()`
- Added `1.20.6` and `1.21` to versions that can run the plugin
- Prevent some others details