### PR TITLE
Folia Support (#2) Option for gradle, one fix and add table name option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,8 @@ processResources {
 }
 
 shadowJar {
-    destinationDirectory.set(file("out"))
+    def pluginDir = System.getProperty('plugin.dir')
+    destinationDirectory.set(file(pluginDir == null ? "out" : pluginDir))
     relocate 'com.saicone.ezlib', project.group + '.hdrawer.lib.ezlib'
     relocate 'com.mongodb', project.group + '.hdrawer.lib.mongodb'
     relocate 'com.zaxxer.hikari', project.group + '.hdrawer.lib.hikari'

--- a/src/main/java/fr/hokib/hdrawer/command/DrawerCommand.java
+++ b/src/main/java/fr/hokib/hdrawer/command/DrawerCommand.java
@@ -95,7 +95,8 @@ public class DrawerCommand implements CommandExecutor, TabCompleter {
         return Collections.emptyList();
     }
 
-    public boolean sendHelp(final CommandSender sender) {
+    @SuppressWarnings("deprecation")
+	public boolean sendHelp(final CommandSender sender) {
         sender.sendMessage(" ");
         sender.sendMessage(ColorUtil.color("§8------ &#E747FBH&#D042FCD&#B83DFCr&#A138FDa&#8A33FEw&#722EFEe&#5B29FFr§8 ------"));
         sender.sendMessage(" ");

--- a/src/main/java/fr/hokib/hdrawer/config/database/DatabaseConfig.java
+++ b/src/main/java/fr/hokib/hdrawer/config/database/DatabaseConfig.java
@@ -3,14 +3,15 @@ package fr.hokib.hdrawer.config.database;
 import org.bukkit.configuration.ConfigurationSection;
 
 public record DatabaseConfig(String type, String connectionString, String host, String port, String database,
-                             String username, String password, long savePeriod) {
+                             String tableName, String username, String password, long savePeriod) {
 
     public static DatabaseConfig fromConfig(final ConfigurationSection section) {
-        if (section == null) return new DatabaseConfig("JSON", "", "", "", "", "", "", 300000L);
+        if (section == null) return new DatabaseConfig("JSON", "", "", "", "", "drawers", "", "", 300000L);
 
         final String type = section.getString("type");
         final long savePeriod = section.getLong("save-period");
         final String database = section.getString("database");
+        final String tableName = section.getString("table-name");
         //MONGODB
         final String connectionString = section.getString("mongodb.connection-string");
 
@@ -25,7 +26,7 @@ public record DatabaseConfig(String type, String connectionString, String host, 
             password = mysqlSection.getString("password");
         }
 
-        return new DatabaseConfig(type, connectionString, host, port, database,
+        return new DatabaseConfig(type, connectionString, host, port, database, tableName,
                 username, password, savePeriod);
     }
 }

--- a/src/main/java/fr/hokib/hdrawer/config/drawer/DrawerConfig.java
+++ b/src/main/java/fr/hokib/hdrawer/config/drawer/DrawerConfig.java
@@ -20,7 +20,8 @@ public record DrawerConfig(String id, ItemStack drawer, Material borderMaterial,
     private static final String RECIPE_ID = "drawer-recipe";
     private static final char[] symbols = new char[]{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'};
 
-    public static DrawerConfig fromConfig(final ConfigurationSection section) {
+    @SuppressWarnings("deprecation")
+	public static DrawerConfig fromConfig(final ConfigurationSection section) {
         final String id = section.getName();
 
         final ConfigurationSection itemSection = section.getConfigurationSection("item");

--- a/src/main/java/fr/hokib/hdrawer/database/Database.java
+++ b/src/main/java/fr/hokib/hdrawer/database/Database.java
@@ -1,11 +1,14 @@
 package fr.hokib.hdrawer.database;
 
+import fr.hokib.hdrawer.HDrawer;
 import fr.hokib.hdrawer.config.database.DatabaseConfig;
 import fr.hokib.hdrawer.manager.DrawerManager;
 
 public interface Database {
+	
+	@Deprecated
     String FOLDER = "drawers";
-
+	
     void load(DatabaseConfig config);
 
     /**
@@ -15,4 +18,8 @@ public interface Database {
     void save(DrawerManager manager);
 
     void unload();
+    
+    default DatabaseConfig getConfig() {
+    	return HDrawer.get().getConfiguration().getDatabaseConfig();
+    }
 }

--- a/src/main/java/fr/hokib/hdrawer/database/impl/JsonDatabase.java
+++ b/src/main/java/fr/hokib/hdrawer/database/impl/JsonDatabase.java
@@ -98,6 +98,6 @@ public class JsonDatabase implements Database {
     }
 
     private Path getPath() {
-        return Path.of(HDrawer.get().getDataFolder().getPath(), FOLDER);
+        return Path.of(HDrawer.get().getDataFolder().getPath(), getConfig().tableName());
     }
 }

--- a/src/main/java/fr/hokib/hdrawer/database/impl/MongoDatabase.java
+++ b/src/main/java/fr/hokib/hdrawer/database/impl/MongoDatabase.java
@@ -111,11 +111,11 @@ public class MongoDatabase implements Database {
     private MongoCollection<DrawerData> createCollectionIfNotExist(final com.mongodb.client.MongoDatabase database) {
         if (database == null) return null;
 
-        if (!database.listCollectionNames().into(new ArrayList<>()).contains(FOLDER)) {
-            database.createCollection(FOLDER);
+        if (!database.listCollectionNames().into(new ArrayList<>()).contains(getConfig().tableName())) {
+            database.createCollection(getConfig().tableName());
         }
 
-        return database.getCollection(FOLDER, DrawerData.class);
+        return database.getCollection(getConfig().tableName(), DrawerData.class);
     }
 
     private Bson getFilter(final String location) {

--- a/src/main/java/fr/hokib/hdrawer/manager/DrawerManager.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/DrawerManager.java
@@ -78,14 +78,10 @@ public class DrawerManager {
     public boolean remove(final Location location) {
         final String stringLocation = LocationUtil.convert(location);
         final Drawer drawer = this.drawers.remove(stringLocation);
-        if (drawer == null) {
-        	HDrawer.get().getLogger().warning("Drawer not found : " + stringLocation);
-        	return false;
-        }
+        if (drawer == null) return false;
 
         this.deleted.add(stringLocation);
         this.unsaved.remove(stringLocation);
-    	HDrawer.get().getLogger().warning("drawer removing, deleted: " + String.join(", ", deleted) + ", unsaved: " + String.join(", ", unsaved));
 
         final DrawerConfig config = HDrawer.get().getConfiguration().getDrawerConfig(drawer.getId());
         final ItemStack toDrop = config.drawer().clone();

--- a/src/main/java/fr/hokib/hdrawer/manager/DrawerManager.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/DrawerManager.java
@@ -78,10 +78,14 @@ public class DrawerManager {
     public boolean remove(final Location location) {
         final String stringLocation = LocationUtil.convert(location);
         final Drawer drawer = this.drawers.remove(stringLocation);
-        if (drawer == null) return false;
+        if (drawer == null) {
+        	HDrawer.get().getLogger().warning("Drawer not found : " + stringLocation);
+        	return false;
+        }
 
         this.deleted.add(stringLocation);
         this.unsaved.remove(stringLocation);
+    	HDrawer.get().getLogger().warning("drawer removing, deleted: " + String.join(", ", deleted) + ", unsaved: " + String.join(", ", unsaved));
 
         final DrawerConfig config = HDrawer.get().getConfiguration().getDrawerConfig(drawer.getId());
         final ItemStack toDrop = config.drawer().clone();
@@ -133,7 +137,9 @@ public class DrawerManager {
     }
 
     public void save(final Location location) {
-        this.unsaved.add(LocationUtil.convert(location));
+    	String s = LocationUtil.convert(location);
+    	if(!this.unsaved.contains(s)) // prevent beeing added multiple times
+    		this.unsaved.add(s);
     }
 
     public void hideAll() {

--- a/src/main/java/fr/hokib/hdrawer/manager/drawer/Drawer.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/drawer/Drawer.java
@@ -5,6 +5,7 @@ import fr.hokib.hdrawer.config.Config;
 import fr.hokib.hdrawer.config.drawer.DrawerConfig;
 import fr.hokib.hdrawer.manager.drawer.data.DrawerStorage;
 import fr.hokib.hdrawer.manager.drawer.type.DrawerType;
+import fr.hokib.hdrawer.scheduler.Scheduler;
 import fr.hokib.hdrawer.util.NumberUtil;
 import fr.hokib.hdrawer.util.location.BorderTuple;
 import fr.hokib.hdrawer.util.location.DisplayAttributes;
@@ -111,7 +112,7 @@ public class Drawer extends DrawerStorage {
                 itemDisplay.setInvulnerable(true);
                 itemDisplay.setPersistent(false);
                 itemDisplay.setViewRange(config.getDistance());
-                itemDisplay.teleport(itemLocation);
+                Scheduler.getScheduler().teleportEntity(itemDisplay, itemLocation);
             }).getUniqueId());
 
             //TextDisplay
@@ -129,7 +130,7 @@ public class Drawer extends DrawerStorage {
                 textDisplay.setPersistent(false);
                 textDisplay.setBackgroundColor(Color.fromARGB(0, 0, 0, 0));
                 textDisplay.setViewRange(config.getDistance());
-                textDisplay.teleport(textLocation);
+                Scheduler.getScheduler().teleportEntity(textDisplay, textLocation);
             }).getUniqueId());
 
             if (i < this.content.size()) {
@@ -159,7 +160,7 @@ public class Drawer extends DrawerStorage {
                     border.setItemDisplayTransform(ItemDisplay.ItemDisplayTransform.FIXED);
                     border.setPersistent(false);
                     border.setInvulnerable(true);
-                    border.teleport(location);
+                    Scheduler.getScheduler().teleportEntity(border, location);
                 }).getUniqueId());
             }
         }

--- a/src/main/java/fr/hokib/hdrawer/manager/drawer/data/DrawerData.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/drawer/data/DrawerData.java
@@ -1,13 +1,14 @@
 package fr.hokib.hdrawer.manager.drawer.data;
 
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+
 import fr.hokib.hdrawer.HDrawer;
 import fr.hokib.hdrawer.config.drawer.DrawerConfig;
 import fr.hokib.hdrawer.manager.drawer.Drawer;
+import fr.hokib.hdrawer.scheduler.Scheduler;
 import fr.hokib.hdrawer.util.Base64ItemStack;
 import fr.hokib.hdrawer.util.location.LocationUtil;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.BlockFace;
 
 public record DrawerData(String content, String id, String location, BlockFace face) {
 
@@ -30,7 +31,7 @@ public record DrawerData(String content, String id, String location, BlockFace f
         drawer.setLocation(location);
         drawer.setFace(this.face);
 
-        Bukkit.getScheduler().runTask(HDrawer.get(), () -> {
+        Scheduler.getScheduler().runInRegion(location, () -> {
             drawer.build();
             drawer.setContent(Base64ItemStack.decode(this.content));
         });

--- a/src/main/java/fr/hokib/hdrawer/manager/hopper/HopperManager.java
+++ b/src/main/java/fr/hokib/hdrawer/manager/hopper/HopperManager.java
@@ -4,6 +4,7 @@ import fr.hokib.hdrawer.HDrawer;
 import fr.hokib.hdrawer.config.Config;
 import fr.hokib.hdrawer.manager.DrawerManager;
 import fr.hokib.hdrawer.manager.drawer.Drawer;
+import fr.hokib.hdrawer.scheduler.Scheduler;
 import fr.hokib.hdrawer.util.inventory.InventoryUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -32,12 +33,14 @@ public class HopperManager implements Runnable {
     @Override
     public void run() {
         for (final Drawer drawer : this.manager.getDrawers().values()) {
-            if (!drawer.getLocation().getChunk().isLoaded()) continue;
-
-            final Optional<Hopper> bottom = this.getBottom(drawer);
-            bottom.ifPresent(hopper -> this.transit(drawer, hopper));
-
-            this.transit(this.getSides(drawer), drawer);
+        	Scheduler.getScheduler().runInRegion(drawer.getLocation(), () -> {
+	            if (!drawer.getLocation().getChunk().isLoaded()) return;
+	
+	            final Optional<Hopper> bottom = this.getBottom(drawer);
+	            bottom.ifPresent(hopper -> this.transit(drawer, hopper));
+	
+	            this.transit(this.getSides(drawer), drawer);
+        	});
         }
     }
 

--- a/src/main/java/fr/hokib/hdrawer/scheduler/ScheduledTask.java
+++ b/src/main/java/fr/hokib/hdrawer/scheduler/ScheduledTask.java
@@ -1,0 +1,5 @@
+package fr.hokib.hdrawer.scheduler;
+
+public interface ScheduledTask {
+	void cancel();
+}

--- a/src/main/java/fr/hokib/hdrawer/scheduler/Scheduler.java
+++ b/src/main/java/fr/hokib/hdrawer/scheduler/Scheduler.java
@@ -1,0 +1,92 @@
+package fr.hokib.hdrawer.scheduler;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+import fr.hokib.hdrawer.HDrawer;
+
+public interface Scheduler {
+
+	void run(Runnable task);
+
+	void runInRegion(Location loc, Runnable task);
+
+	void runAsync(Runnable task);
+	
+	default void runEntity(Entity entity, Runnable task) {
+		run(task);
+	}
+	
+	void runRepeating(Consumer<ScheduledTask> task, int delayTicks, int intervalTicks);
+	
+	/**
+	 * Run the given task each given ticks, after waiting a delay
+	 * 
+	 * @param task task to run
+	 * @param delayTicks delay before starting task
+	 * @param intervalTicks ticks between each task runned
+	 * @return the running task
+	 */
+	ScheduledTask runRepeating(Runnable task, int delayTicks, int intervalTicks);
+	
+	default ScheduledTask runRepeating(Runnable task, int intervalTicks) {
+		return runRepeating(task, intervalTicks, null);
+	}
+	
+	/**
+	 * Run repeating task each given ticks
+	 * 
+	 * @param task the task to run
+	 * @param intervalTicks ticks between each call
+	 * @param name name of task (may be ignored)
+	 * @return the running task
+	 */
+	ScheduledTask runRepeating(Runnable task, int intervalTicks, @Nullable String name);
+	
+	/**
+	 * Run task after waiting given ticks
+	 * 
+	 * @param task task to run
+	 * @param delayTicks ticks before running task
+	 * @return the running task
+	 */
+	ScheduledTask runDelayed(Runnable task, int delayTicks);
+	
+	/**
+	 * Run repeating task each given ticks according to given entity
+	 * 
+	 * @param entity The entity which this task is about
+	 * @param task the task to run
+	 * @param delayTicks delay before starting task
+	 * @param intervalTicks ticks between each task runned
+	 * @return the running task
+	 */
+	default ScheduledTask runEntityRepeating(Entity entity, Runnable task, int delayTicks, int intervalTicks) {
+		return runRepeating(task, delayTicks, intervalTicks);
+	}
+	
+	/**
+	 * Run task after waiting given ticks according to given entity
+	 * 
+	 * @param entity The entity which this task is about
+	 * @param task task to run
+	 * @param delayTicks ticks before running task
+	 * @return the running task
+	 */
+	default ScheduledTask runEntityDelayed(Entity entity, Runnable task, int delayTicks) {
+		return runDelayed(task, delayTicks);
+	}
+	
+	void teleportEntity(Entity entity, Location location);
+	
+	ScheduledTask runRepeatingAsync(Runnable task, Duration delay, Duration interval, @Nullable String name);
+	
+	static Scheduler getScheduler() {
+		return HDrawer.get().getScheduler();
+	}
+}

--- a/src/main/java/fr/hokib/hdrawer/scheduler/hook/FoliaScheduler.java
+++ b/src/main/java/fr/hokib/hdrawer/scheduler/hook/FoliaScheduler.java
@@ -1,0 +1,167 @@
+package fr.hokib.hdrawer.scheduler.hook;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import fr.hokib.hdrawer.scheduler.ScheduledTask;
+import fr.hokib.hdrawer.scheduler.Scheduler;
+import fr.hokib.hdrawer.util.ReflectionUtils;
+
+public class FoliaScheduler implements Scheduler {
+
+	private Plugin plugin;
+	private Object globalRegionScheduler = null, regionScheduler = null, asyncScheduler = null;
+
+	public FoliaScheduler(Plugin plugin) {
+		this.plugin = plugin;
+		this.globalRegionScheduler = ReflectionUtils.callStaticMethod(Bukkit.class, "getGlobalRegionScheduler");
+		this.regionScheduler = ReflectionUtils.callStaticMethod(Bukkit.class, "getRegionScheduler");
+		this.asyncScheduler = ReflectionUtils.callStaticMethod(Bukkit.class, "getAsyncScheduler");
+	}
+
+	@Override
+	public void run(Runnable task) {
+		try {
+			globalRegionScheduler.getClass().getDeclaredMethod("run", Plugin.class, Consumer.class).invoke(globalRegionScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Override
+	public void runInRegion(Location loc, Runnable task) {
+		try {
+			Class.forName("io.papermc.paper.threadedregions.scheduler.RegionScheduler").getDeclaredMethod("execute", Plugin.class, Location.class, Runnable.class).invoke(regionScheduler, this.plugin, loc, task);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void runAsync(Runnable task) {
+		try {
+			asyncScheduler.getClass().getDeclaredMethod("runNow", Plugin.class, Consumer.class).invoke(asyncScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Override
+	public void runEntity(Entity entity, Runnable task) {
+		try {
+			Object scheduler = getEntityScheduler(entity);
+			scheduler.getClass().getDeclaredMethod("run", Plugin.class, Consumer.class, Runnable.class).invoke(scheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), null);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Override
+	public void runRepeating(Consumer<ScheduledTask> task, int delayTicks, int intervalTicks) {
+		try {
+			globalRegionScheduler.getClass().getDeclaredMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class).invoke(globalRegionScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.accept(new TaskWrapper(scheduledTask)), delayTicks, intervalTicks);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public ScheduledTask runRepeating(Runnable task, int delayTicks, int intervalTicks) {
+		try {
+			Method method = globalRegionScheduler.getClass().getDeclaredMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+			return new TaskWrapper(method.invoke(globalRegionScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), delayTicks, intervalTicks));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	@Override
+	public ScheduledTask runRepeating(Runnable task, int intervalTicks, @Nullable String name) {
+		return runRepeating(task, 1, intervalTicks);
+	}
+
+	@Override
+	public ScheduledTask runDelayed(Runnable task, int delayTicks) {
+		try {
+			Method method = globalRegionScheduler.getClass().getDeclaredMethod("runDelayed", Plugin.class, Consumer.class, long.class);
+			return new TaskWrapper(method.invoke(globalRegionScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), delayTicks));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	@Override
+	public ScheduledTask runEntityRepeating(Entity entity, Runnable task, int delayTicks, int intervalTicks) {
+		try {
+			Object scheduler = getEntityScheduler(entity);
+			Method method = scheduler.getClass().getDeclaredMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+			return new TaskWrapper(method.invoke(scheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), delayTicks, intervalTicks));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	@Override
+	public ScheduledTask runEntityDelayed(Entity entity, Runnable task, int delayTicks) {
+		try {
+			Object scheduler = getEntityScheduler(entity);
+			Method method = scheduler.getClass().getDeclaredMethod("runDelayed", Plugin.class, Consumer.class, Runnable.class ,long.class);
+			return new TaskWrapper(method.invoke(scheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), null, delayTicks));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+	
+	private Object getEntityScheduler(Entity entity) throws Exception {
+		return org.bukkit.entity.Entity.class.getDeclaredMethod("getScheduler").invoke(entity);
+	}
+
+	@Override
+	public ScheduledTask runRepeatingAsync(Runnable task, Duration delay, Duration interval, @Nullable String name) {
+		try {
+			Method method = asyncScheduler.getClass().getDeclaredMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class, TimeUnit.class);
+			return new TaskWrapper(method.invoke(asyncScheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), delay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+	
+	@Override
+	public void teleportEntity(Entity entity, Location location) {
+		entity.teleportAsync(location);
+	}
+
+	private static class TaskWrapper implements ScheduledTask {
+
+		// type io.papermc.paper.threadedregions.scheduler.ScheduledTask
+		private final Object scheduledTask;
+
+		private TaskWrapper(Object scheduledTask) {
+			this.scheduledTask = scheduledTask;
+		}
+
+		@Override
+		public void cancel() {
+			try {
+				Method m = scheduledTask.getClass().getDeclaredMethod("cancel");
+				m.setAccessible(true);
+				m.invoke(scheduledTask);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/src/main/java/fr/hokib/hdrawer/scheduler/hook/SpigotScheduler.java
+++ b/src/main/java/fr/hokib/hdrawer/scheduler/hook/SpigotScheduler.java
@@ -1,0 +1,111 @@
+package fr.hokib.hdrawer.scheduler.hook;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import fr.hokib.hdrawer.scheduler.ScheduledTask;
+import fr.hokib.hdrawer.scheduler.Scheduler;
+
+public class SpigotScheduler implements Scheduler {
+	
+	private Plugin plugin;
+	
+	public SpigotScheduler(Plugin plugin) {
+		this.plugin = plugin;
+	}
+	
+	@Override
+	public void run(Runnable task) {
+		if(Bukkit.isPrimaryThread())
+			task.run();
+		else
+			Bukkit.getScheduler().runTask(plugin, task);
+	}
+	
+	@Override
+	public void runInRegion(Location loc, Runnable task) {
+		run(task);
+	}
+	
+	@Override
+	public void runAsync(Runnable task) {
+		if(Bukkit.isPrimaryThread())
+			task.run();
+		else
+			Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+	}
+	
+	@Override
+	public void runRepeating(Consumer<ScheduledTask> task, int delayTicks, int intervalTicks) {
+		new BukkitRunnable() {
+			private final ScheduledTask wrapper = new BukkitRunnableWrapper(this);
+			@Override
+			public void run() {
+				task.accept(this.wrapper);
+			}
+		}.runTaskTimer(this.plugin, delayTicks, intervalTicks);
+	}
+	
+	@Override
+	public ScheduledTask runRepeating(Runnable task, int delayTicks, int intervalTicks) {
+		return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(this.plugin, task, delayTicks, intervalTicks));
+	}
+	
+	@Override
+	public ScheduledTask runRepeating(Runnable task, int intervalTicks, @Nullable String name) {
+		return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(this.plugin, task, 0, intervalTicks));
+	}
+	
+	@Override
+	public ScheduledTask runDelayed(Runnable task, int delayTicks) {
+		return new TaskWrapper(Bukkit.getScheduler().runTaskLater(this.plugin, task, delayTicks));
+	}
+	
+	@Override
+	public ScheduledTask runRepeatingAsync(Runnable task, Duration delay, Duration interval, @Nullable String name) {
+		long delayTicks = (delay.toMillis() * 20) / 1000;
+		long intervalTicks = (interval.toMillis() * 20) / 1000;
+		return new TaskWrapper(Bukkit.getScheduler().runTaskTimerAsynchronously(this.plugin, task, delayTicks, intervalTicks));
+	}
+	
+	@Override
+	public void teleportEntity(Entity entity, Location location) {
+		entity.teleport(location);
+	}
+	
+	private static class TaskWrapper implements ScheduledTask {
+		
+		private final BukkitTask task;
+		
+		private TaskWrapper(BukkitTask task) {
+			this.task = task;
+		}
+		
+		@Override
+		public void cancel() {
+			this.task.cancel();
+		}
+	}
+	
+	private static class BukkitRunnableWrapper implements ScheduledTask {
+		
+		private final BukkitRunnable task;
+		
+		private BukkitRunnableWrapper(BukkitRunnable task) {
+			this.task = task;
+		}
+		
+		@Override
+		public void cancel() {
+			this.task.cancel();
+		}
+	}
+}

--- a/src/main/java/fr/hokib/hdrawer/util/ReflectionUtils.java
+++ b/src/main/java/fr/hokib/hdrawer/util/ReflectionUtils.java
@@ -1,0 +1,29 @@
+package fr.hokib.hdrawer.util;
+
+public class ReflectionUtils {
+	
+	/**
+	 * Call static method. Return the method return.
+	 * 
+	 * @param source the object where we want to run the method
+	 * @param method the name of the method to call
+	 * @return the return of the method called
+	 */
+	public static Object callStaticMethod(Class<?> source, String method) {
+		try {
+			return source.getDeclaredMethod(method).invoke(null);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	public static boolean isClassExist(String clazz) {
+		try {
+			Class.forName(clazz);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/fr/hokib/hdrawer/util/version/UpdateChecker.java
+++ b/src/main/java/fr/hokib/hdrawer/util/version/UpdateChecker.java
@@ -1,13 +1,12 @@
 package fr.hokib.hdrawer.util.version;
 
-import fr.hokib.hdrawer.HDrawer;
-import org.bukkit.Bukkit;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Scanner;
 import java.util.function.Consumer;
+
+import fr.hokib.hdrawer.scheduler.Scheduler;
 
 public class UpdateChecker {
 
@@ -15,7 +14,7 @@ public class UpdateChecker {
     public static final String RESOURCE_URL = "https://www.spigotmc.org/resources/hdrawer." + RESOURCE_ID + "/";
 
     public static void getVersion(final Consumer<String> consumer) {
-        Bukkit.getScheduler().runTaskAsynchronously(HDrawer.get(), () -> {
+        Scheduler.getScheduler().runAsync(() -> {
             try (final InputStream is = new URL("https://api.spigotmc.org/legacy/update.php?resource=" + RESOURCE_ID + "/~").openStream(); Scanner scanner = new Scanner(is)) {
                 if (scanner.hasNext()) {
                     consumer.accept(scanner.next());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,7 @@ database:
   type: JSON
   save-period: 300000 #Every 5mins
   database: "database"
+  table-name: "drawers"
   mongodb:
     connection-string: "mongodb+srv://<username>:<password>@<host>/?retryWrites=true&w=majority"
   mysql:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: fr.hokib.hdrawer.HDrawer
 authors: [ Hokib ]
 website: https://hokib.com
 api-version: '1.13'
+folia-supported: true
 softdepend:
   - SuperiorSkyblock2
   - BentoBox


### PR DESCRIPTION
Ajout de 3 choses :
- Support de Folia ! #2 
- `plugin.dir` lors de la compilation pour changer le dossier de destination (optionel)
- Fix d'une erreur possible si on supprime un drawer avant qu'il ait été sauvegardé une première fois
- Ajout d'une option `table-name` pour pouvoir changer le nom de la table utilisé par mysql/mongodb

(Note: je recommande de faire un "Squash and merge" pour migrer la PR)